### PR TITLE
Add Spanish language

### DIFF
--- a/lib/Date/Names.pm6
+++ b/lib/Date/Names.pm6
@@ -159,9 +159,9 @@ constant %mon3 is export = %(
 
     # Spanish
     es => %(
-        1, '',    2, '',  3, '',     4,  '',
-        5, '',        6, '',      7, '',      8,  '',
-        9, '', 10, '',  11, '', 12, ''
+        1, 'ene',    2, 'feb',  3, 'mar',     4,  'abr',
+        5, 'may',    6, 'jun',  7, 'jul',     8,  'ago',
+        9, 'sep',   10, 'oct', 11, 'nov',    12,  'dic'
     ),
 
     # French
@@ -220,8 +220,8 @@ constant %dow2 is export = %(
 
     # Spanish
     es => %(
-        1, '',    2, '',  3, '',     4,  '',
-        5, '',        6, '',      7, ''
+        1, 'lu',    2, 'ma',  3, 'mi',     4,  'ju',
+        5, 'vi',    6, 'sá',  7, 'do'
     ),
 
     # French
@@ -275,8 +275,8 @@ constant %dow3 is export = %(
 
     # Spanish
     es => %(
-        1, '',    2, '',  3, '',     4,  '',
-        5, '',        6, '',      7, ''
+        1, 'lun',  2, 'mar',  3, 'mié',  4, 'jue',
+        5, 'vie',  6, 'sáb',  7, 'dom'
     ),
 
     # French


### PR DESCRIPTION
I've used the following sources:

1. http://www.wikilengua.org/index.php/Abreviaciones_en_fechas.
2. http://lema.rae.es/dpd/srv/search?id=fKODyKTfZD6s0mX7bz

to fill out the Spanish hashes.

It's worth mentioning that, according to these sources, none of your hashes for Spanish months and days of the week would be considered abbreviations.  In their treatment of it, an abbreviation doesn't seem to be defined by the number of letters since there's not a straightforward way of forming abbreviations in Spanish [2]. For example, `lunes` (Monday) is abbreviated as `lun.`, `martes` (Tuesday) as `mart.`, `miércoles` (Wednesday) as `miérc.` and so on.  So, "x-letters abbreviations" maps to "x-letters codes" instead. For example, the three-letters code for the previous days are `lun`, `mar` and `mié` (or `mie`). Thus I've followed the "x-letters codes" convention.




